### PR TITLE
chore: rename events and menus

### DIFF
--- a/client/admin.lua
+++ b/client/admin.lua
@@ -57,19 +57,19 @@ local Options = {
             SetPedInfiniteAmmo(cache.ped, false, weapon)
         end
     end,
-    function(WeaponType) TriggerServerEvent('qb-admin:server:giveallweapons', WeaponType) end,
+    function(WeaponType) TriggerServerEvent('qbx_admin:server:giveAllWeapons', WeaponType) end,
     function() TriggerEvent('police:client:GetCuffed', cache.serverId, true) end,
 }
 
 lib.registerMenu({
-    id = 'qb_adminmenu_admin_menu',
+    id = 'qbx_adminmenu_admin_menu',
     title = Lang:t('title.admin_menu'),
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, 'qb_adminmenu_main_menu')
+        CloseMenu(false, keyPressed, 'qbx_adminmenu_main_menu')
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_admin_menu = selected
+        MenuIndexes.qbx_adminmenu_admin_menu = selected
     end,
     options = {
         {label = Lang:t('admin_options.label1'), description = Lang:t('admin_options.desc1'), icon = 'fab fa-fly', close = false},
@@ -242,7 +242,7 @@ function checkInputRotation()
     end)
 end
 
-RegisterNetEvent('qb-admin:client:noclip', function()
+RegisterNetEvent('qbx_admin:client:noclip', function()
     if GetInvokingResource() then return end -- Safety to make sure it is only called from the server
     toggleNoClipMode()
 end)
@@ -266,12 +266,12 @@ CreateThread(function()
     while true do
         Wait(1000)
         if NetCheck1 or NetCheck2 then
-            TriggerServerEvent('qb-admin:server:GetPlayersForBlips')
+            TriggerServerEvent('qbx_admin:server:getPlayersForBlips')
         end
     end
 end)
 
-RegisterNetEvent('qb-admin:client:blips', function()
+RegisterNetEvent('qbx_admin:client:blips', function()
     if not ShowBlips then
         ShowBlips = true
         NetCheck1 = true
@@ -282,7 +282,7 @@ RegisterNetEvent('qb-admin:client:blips', function()
     end
 end)
 
-RegisterNetEvent('qb-admin:client:names', function()
+RegisterNetEvent('qbx_admin:client:names', function()
     if not ShowNames then
         ShowNames = true
         NetCheck2 = true
@@ -293,7 +293,7 @@ RegisterNetEvent('qb-admin:client:names', function()
     end
 end)
 
-RegisterNetEvent('qb-admin:client:Show', function(players)
+RegisterNetEvent('qbx_admin:client:Show', function(players)
     for _, player in pairs(players) do
         local playeridx = GetPlayerFromServerId(player.id)
         local ped = GetPlayerPed(playeridx)

--- a/client/dev.lua
+++ b/client/dev.lua
@@ -2,10 +2,10 @@ local ShowCoords = false
 local VehicleDev = false
 local VehicleTypes = {'Compacts', 'Sedans', 'SUVs', 'Coupes', 'Muscle', 'Sports Classics', 'Sports', 'Super', 'Motorcycles', 'Off-road', 'Industrial', 'Utility', 'Vans', 'Cycles', 'Boats', 'Helicopters', 'Planes', 'Service', 'Emergency', 'Military', 'Commercial', 'Trains', 'Open Wheel'}
 local Options = {
-    function() CopyToClipboard('coords2') lib.showMenu('qb_adminmenu_dev_menu', MenuIndexes.qb_adminmenu_dev_menu) end,
-    function() CopyToClipboard('coords3') lib.showMenu('qb_adminmenu_dev_menu', MenuIndexes.qb_adminmenu_dev_menu) end,
-    function() CopyToClipboard('coords4') lib.showMenu('qb_adminmenu_dev_menu', MenuIndexes.qb_adminmenu_dev_menu) end,
-    function() CopyToClipboard('heading') lib.showMenu('qb_adminmenu_dev_menu', MenuIndexes.qb_adminmenu_dev_menu) end,
+    function() CopyToClipboard('coords2') lib.showMenu('qbx_adminmenu_dev_menu', MenuIndexes.qbx_adminmenu_dev_menu) end,
+    function() CopyToClipboard('coords3') lib.showMenu('qbx_adminmenu_dev_menu', MenuIndexes.qbx_adminmenu_dev_menu) end,
+    function() CopyToClipboard('coords4') lib.showMenu('qbx_adminmenu_dev_menu', MenuIndexes.qbx_adminmenu_dev_menu) end,
+    function() CopyToClipboard('heading') lib.showMenu('qbx_adminmenu_dev_menu', MenuIndexes.qbx_adminmenu_dev_menu) end,
     function()
         ShowCoords = not ShowCoords
         while ShowCoords do
@@ -35,14 +35,14 @@ local Options = {
 }
 
 lib.registerMenu({
-    id = 'qb_adminmenu_dev_menu',
+    id = 'qbx_adminmenu_dev_menu',
     title = Lang:t('title.dev_menu'),
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, 'qb_adminmenu_main_menu')
+        CloseMenu(false, keyPressed, 'qbx_adminmenu_main_menu')
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_dev_menu = selected
+        MenuIndexes.qbx_adminmenu_dev_menu = selected
     end,
     options = {
         {label = Lang:t('dev_options.label1'), description = Lang:t('dev_options.desc1'), icon = 'fas fa-compass'},

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,24 +1,24 @@
 MenuIndexes = {}
 
 lib.registerMenu({
-    id = 'qb_adminmenu_main_menu',
+    id = 'qbx_adminmenu_main_menu',
     title = Lang:t('title.main_menu'),
     position = 'top-right',
     onClose = function()
         CloseMenu(true)
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_main_menu = selected
+        MenuIndexes.qbx_adminmenu_main_menu = selected
     end,
     options = {
-        {label = Lang:t('main_options.label1'), description = Lang:t('main_options.desc1'), icon = 'fas fa-hammer', args = {'qb_adminmenu_admin_menu'}},
-        {label = Lang:t('main_options.label2'), description = Lang:t('main_options.desc2'), icon = 'fas fa-user', args = {'qb_adminmenu_players_menu'}},
-        {label = Lang:t('main_options.label3'), description = Lang:t('main_options.desc3'), icon = 'fas fa-server', args = {'qb_adminmenu_server_menu'}},
-        {label = Lang:t('main_options.label4'), description = Lang:t('main_options.desc4'), icon = 'fas fa-car', args = {'qb_adminmenu_vehicles_menu'}},
-        {label = Lang:t('main_options.label5'), description = Lang:t('main_options.desc5'), icon = 'fas fa-toolbox', args = {'qb_adminmenu_dev_menu'}}
+        {label = Lang:t('main_options.label1'), description = Lang:t('main_options.desc1'), icon = 'fas fa-hammer', args = {'qbx_adminmenu_admin_menu'}},
+        {label = Lang:t('main_options.label2'), description = Lang:t('main_options.desc2'), icon = 'fas fa-user', args = {'qbx_adminmenu_players_menu'}},
+        {label = Lang:t('main_options.label3'), description = Lang:t('main_options.desc3'), icon = 'fas fa-server', args = {'qbx_adminmenu_server_menu'}},
+        {label = Lang:t('main_options.label4'), description = Lang:t('main_options.desc4'), icon = 'fas fa-car', args = {'qbx_adminmenu_vehicles_menu'}},
+        {label = Lang:t('main_options.label5'), description = Lang:t('main_options.desc5'), icon = 'fas fa-toolbox', args = {'qbx_adminmenu_dev_menu'}}
     }
 }, function(_, _, args)
-    if args[1] == 'qb_adminmenu_players_menu' then
+    if args[1] == 'qbx_adminmenu_players_menu' then
         GeneratePlayersMenu()
     else
         lib.showMenu(args[1], MenuIndexes[args[1]])
@@ -51,11 +51,11 @@ function CloseMenu(isFullMenuClose, keyPressed, previousMenu)
     lib.showMenu(previousMenu, MenuIndexes[previousMenu])
 end
 
-RegisterNetEvent('qb-admin:client:openmenu', function()
-    lib.showMenu('qb_adminmenu_main_menu', MenuIndexes.qb_adminmenu_main_menu)
+RegisterNetEvent('qbx_admin:client:openMenu', function()
+    lib.showMenu('qbx_adminmenu_main_menu', MenuIndexes.qbx_adminmenu_main_menu)
 end)
 
-RegisterNetEvent('qb-admin:client:setmodel', function(skin)
+RegisterNetEvent('qbx_admin:client:setModel', function(skin)
     local model = joaat(skin)
     SetEntityInvincible(cache.ped, true)
     if IsModelInCdimage(model) and IsModelValid(model) then

--- a/client/player.lua
+++ b/client/player.lua
@@ -1,18 +1,18 @@
 local selectedPlayer
 local playerOptions = {
     function()
-        lib.showMenu('qb_adminmenu_player_general_menu', MenuIndexes.qb_adminmenu_player_general_menu)
+        lib.showMenu('qbx_adminmenu_player_general_menu', MenuIndexes.qbx_adminmenu_player_general_menu)
     end,
     function()
-        lib.showMenu('qb_adminmenu_player_administration_menu', MenuIndexes.qb_adminmenu_player_administration_menu)
+        lib.showMenu('qbx_adminmenu_player_administration_menu', MenuIndexes.qbx_adminmenu_player_administration_menu)
     end,
     function()
-        lib.showMenu('qb_adminmenu_player_extra_menu', MenuIndexes.qb_adminmenu_player_extra_menu)
+        lib.showMenu('qbx_adminmenu_player_extra_menu', MenuIndexes.qbx_adminmenu_player_extra_menu)
     end,
     function()
         local Input = lib.inputDialog('Name Change', {'Firstname', 'Lastname'})
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'name', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'name', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -20,7 +20,7 @@ local playerOptions = {
             { type = 'number', label = 'Percentage', min = 0, max = 100 }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'food', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'food', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -28,7 +28,7 @@ local playerOptions = {
             { type = 'number', label = 'Percentage', min = 0, max = 100 }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'thirst', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'thirst', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -36,7 +36,7 @@ local playerOptions = {
             { type = 'number', label = 'Percentage', min = 0, max = 100 }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'stress', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'stress', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -44,13 +44,13 @@ local playerOptions = {
             { type = 'number', label = 'Percentage', min = 0, max = 100 }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'armor', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'armor', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
         local Input = lib.inputDialog('Phone', {'Number'})
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'phone', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'phone', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -58,7 +58,7 @@ local playerOptions = {
             { type = 'number', label = 'Reputation' }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'crafting', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'crafting', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -66,7 +66,7 @@ local playerOptions = {
             { type = 'number', label = 'Reputation' }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'dealer', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'dealer', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -74,7 +74,7 @@ local playerOptions = {
             { type = 'number', label = 'Cash' }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'cash', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'cash', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -82,7 +82,7 @@ local playerOptions = {
             { type = 'number', label = 'Bank' }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'bank', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'bank', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -91,7 +91,7 @@ local playerOptions = {
             { type = 'number', label = 'Grade' }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'job', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'job', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -100,7 +100,7 @@ local playerOptions = {
             { type = 'number', label = 'Grade' }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'gang', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'gang', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
@@ -108,30 +108,30 @@ local playerOptions = {
             { type = 'number', label = 'Frequency' }
         })
         if not Input then GeneratePlayersMenu() return end
-        TriggerServerEvent('qb-admin:server:changeplayerdata', 'radio', selectedPlayer, Input)
+        TriggerServerEvent('qbx_admin:server:changePlayerData', 'radio', selectedPlayer, Input)
         GeneratePlayersMenu()
     end,
     function()
         local License = selectedPlayer.license:gsub('license:', '')
         lib.setClipboard(License)
-        lib.showMenu(('qb_adminmenu_player_menu_%s'):format(selectedPlayer.id), MenuIndexes[('qb_adminmenu_player_menu_%s'):format(selectedPlayer.id)])
+        lib.showMenu(('qbx_adminmenu_player_menu_%s'):format(selectedPlayer.id), MenuIndexes[('qbx_adminmenu_player_menu_%s'):format(selectedPlayer.id)])
     end,
     function()
         local Discord = selectedPlayer.discord:gsub('discord:', '')
         lib.setClipboard(Discord)
-        lib.showMenu(('qb_adminmenu_player_menu_%s'):format(selectedPlayer.id), MenuIndexes[('qb_adminmenu_player_menu_%s'):format(selectedPlayer.id)])
+        lib.showMenu(('qbx_adminmenu_player_menu_%s'):format(selectedPlayer.id), MenuIndexes[('qbx_adminmenu_player_menu_%s'):format(selectedPlayer.id)])
     end,
     function()
         local Steam = selectedPlayer.steam:gsub('steam:', '')
         lib.setClipboard(Steam)
-        lib.showMenu(('qb_adminmenu_player_menu_%s'):format(selectedPlayer.id), MenuIndexes[('qb_adminmenu_player_menu_%s'):format(selectedPlayer.id)])
+        lib.showMenu(('qbx_adminmenu_player_menu_%s'):format(selectedPlayer.id), MenuIndexes[('qbx_adminmenu_player_menu_%s'):format(selectedPlayer.id)])
     end,
 }
 
 function GeneratePlayersMenu()
-    local players = lib.callback.await('qb-admin:server:getplayers', false)
+    local players = lib.callback.await('qbx_admin:server:getPlayers', false)
     if not players then
-        lib.showMenu('qb_adminmenu_main_menu', MenuIndexes.qb_adminmenu_main_menu)
+        lib.showMenu('qbx_adminmenu_main_menu', MenuIndexes.qbx_adminmenu_main_menu)
         return
     end
     local optionsList = {}
@@ -139,31 +139,31 @@ function GeneratePlayersMenu()
         optionsList[#optionsList + 1] = {label = string.format('ID: %s | Name: %s', players[i].id, players[i].name), description = string.format('CID: %s | %s', players[i].cid, players[i].license), args = {players[i]}}
     end
     lib.registerMenu({
-        id = 'qb_adminmenu_players_menu',
+        id = 'qbx_adminmenu_players_menu',
         title = Lang:t('title.players_menu'),
         position = 'top-right',
         onClose = function(keyPressed)
-            CloseMenu(false, keyPressed, 'qb_adminmenu_main_menu')
+            CloseMenu(false, keyPressed, 'qbx_adminmenu_main_menu')
         end,
         onSelected = function(selected)
-            MenuIndexes.qb_adminmenu_players_menu = selected
+            MenuIndexes.qbx_adminmenu_players_menu = selected
         end,
         options = optionsList
     }, function(_, _, args)
-        local player = lib.callback.await('qb-admin:server:getplayer', false, args[1].id)
+        local player = lib.callback.await('qbx_admin:server:getPlayer', false, args[1].id)
         if not player then
-            lib.showMenu('qb_adminmenu_main_menu', MenuIndexes.qb_adminmenu_main_menu)
+            lib.showMenu('qbx_adminmenu_main_menu', MenuIndexes.qbx_adminmenu_main_menu)
             return
         end
         lib.registerMenu({
-            id = ('qb_adminmenu_player_menu_%s'):format(args[1].id),
+            id = ('qbx_adminmenu_player_menu_%s'):format(args[1].id),
             title = player.name,
             position = 'top-right',
             onClose = function(keyPressed)
-                CloseMenu(false, keyPressed, 'qb_adminmenu_players_menu')
+                CloseMenu(false, keyPressed, 'qbx_adminmenu_players_menu')
             end,
             onSelected = function(selected)
-                MenuIndexes[('qb_adminmenu_player_menu_%s'):format(args[1].id)] = selected
+                MenuIndexes[('qbx_adminmenu_player_menu_%s'):format(args[1].id)] = selected
             end,
             options = {
                 {label = Lang:t('player_options.label1'), description = Lang:t('player_options.desc1'), icon = 'fas fa-wrench'},
@@ -190,20 +190,20 @@ function GeneratePlayersMenu()
             playerOptions[selected]()
         end)
         selectedPlayer = player
-        lib.showMenu(('qb_adminmenu_player_menu_%s'):format(args[1].id), MenuIndexes[('qb_adminmenu_player_menu_%s'):format(args[1].id)])
+        lib.showMenu(('qbx_adminmenu_player_menu_%s'):format(args[1].id), MenuIndexes[('qbx_adminmenu_player_menu_%s'):format(args[1].id)])
     end)
-    lib.showMenu('qb_adminmenu_players_menu', MenuIndexes.qb_adminmenu_players_menu)
+    lib.showMenu('qbx_adminmenu_players_menu', MenuIndexes.qbx_adminmenu_players_menu)
 end
 
 lib.registerMenu({
-    id = 'qb_adminmenu_player_general_menu',
+    id = 'qbx_adminmenu_player_general_menu',
     title = Lang:t('player_options.label1'),
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, ('qb_adminmenu_player_menu_%s'):format(selectedPlayer?.id))
+        CloseMenu(false, keyPressed, ('qbx_adminmenu_player_menu_%s'):format(selectedPlayer?.id))
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_player_general_menu = selected
+        MenuIndexes.qbx_adminmenu_player_general_menu = selected
     end,
     options = {
         {label = Lang:t('player_options.general.labelkill'), description = Lang:t('player_options.general.desckill'), icon = 'fas fa-skull', close = false},
@@ -220,22 +220,22 @@ lib.registerMenu({
             { type = 'number', label = Lang:t('player_options.general.labelrouting'), placeholder = '25'}
         })
         if not Input then return end if not Input[1] then return end
-        TriggerServerEvent('qb-admin:server:playeroptionsgeneral', selected, selectedPlayer, Input[1])
-        lib.showMenu(('qb_adminmenu_player_menu_%s'):format(selectedPlayer?.id), MenuIndexes[('qb_adminmenu_player_menu_%s'):format(selectedPlayer?.id)])
+        TriggerServerEvent('qbx_admin:server:playerOptionsGeneral', selected, selectedPlayer, Input[1])
+        lib.showMenu(('qbx_adminmenu_player_menu_%s'):format(selectedPlayer?.id), MenuIndexes[('qbx_adminmenu_player_menu_%s'):format(selectedPlayer?.id)])
     else
-        TriggerServerEvent('qb-admin:server:playeroptionsgeneral', selected, selectedPlayer)
+        TriggerServerEvent('qbx_admin:server:playerOptionsGeneral', selected, selectedPlayer)
     end
 end)
 
 lib.registerMenu({
-    id = 'qb_adminmenu_player_administration_menu',
+    id = 'qbx_adminmenu_player_administration_menu',
     title = Lang:t('player_options.label2'),
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, ('qb_adminmenu_player_menu_%s'):format(selectedPlayer?.id))
+        CloseMenu(false, keyPressed, ('qbx_adminmenu_player_menu_%s'):format(selectedPlayer?.id))
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_player_administration_menu = selected
+        MenuIndexes.qbx_adminmenu_player_administration_menu = selected
     end,
     options = {
         {label = Lang:t('player_options.administration.labelkick'), description = Lang:t('player_options.administration.desckick'), icon = 'fas fa-plane-departure'},
@@ -246,9 +246,9 @@ lib.registerMenu({
 }, function(selected, scrollIndex, args)
     if selected == 1 then
         local Input = lib.inputDialog(selectedPlayer.name, {Lang:t('player_options.administration.inputkick')})
-        if not Input then lib.showMenu('qb_adminmenu_player_administration_menu', MenuIndexes.qb_adminmenu_player_administration_menu) return end if not Input[1] then return end
-        TriggerServerEvent('qb-admin:server:playeradministration', selected, selectedPlayer, Input[1])
-        lib.showMenu('qb_adminmenu_player_administration_menu', MenuIndexes.qb_adminmenu_player_administration_menu)
+        if not Input then lib.showMenu('qbx_adminmenu_player_administration_menu', MenuIndexes.qbx_adminmenu_player_administration_menu) return end if not Input[1] then return end
+        TriggerServerEvent('qbx_admin:server:playerAdministration', selected, selectedPlayer, Input[1])
+        lib.showMenu('qbx_adminmenu_player_administration_menu', MenuIndexes.qbx_adminmenu_player_administration_menu)
     elseif selected == 2 then
         local Input = lib.inputDialog(selectedPlayer.name, {
             { type = 'input', label = Lang:t('player_options.administration.inputkick'), placeholder = 'VDM'},
@@ -256,24 +256,24 @@ lib.registerMenu({
             { type = 'number', label = Lang:t('player_options.administration.input2ban')},
             { type = 'number', label = Lang:t('player_options.administration.input3ban')}
         })
-        if not Input then lib.showMenu('qb_adminmenu_player_administration_menu', MenuIndexes.qb_adminmenu_player_general_menu) return end if not Input[1] or not Input[2] and not Input[3] and not Input[4] then return end
-        TriggerServerEvent('qb-admin:server:playeradministration', selected, selectedPlayer, Input)
-        lib.showMenu('qb_adminmenu_player_administration_menu', MenuIndexes.qb_adminmenu_player_administration_menu)
+        if not Input then lib.showMenu('qbx_adminmenu_player_administration_menu', MenuIndexes.qbx_adminmenu_player_general_menu) return end if not Input[1] or not Input[2] and not Input[3] and not Input[4] then return end
+        TriggerServerEvent('qbx_admin:server:playerAdministration', selected, selectedPlayer, Input)
+        lib.showMenu('qbx_adminmenu_player_administration_menu', MenuIndexes.qbx_adminmenu_player_administration_menu)
     else
-        TriggerServerEvent('qb-admin:server:playeradministration', selected, selectedPlayer, args[scrollIndex])
-        lib.showMenu('qb_adminmenu_player_administration_menu', MenuIndexes.qb_adminmenu_player_administration_menu)
+        TriggerServerEvent('qbx_admin:server:playerAdministration', selected, selectedPlayer, args[scrollIndex])
+        lib.showMenu('qbx_adminmenu_player_administration_menu', MenuIndexes.qbx_adminmenu_player_administration_menu)
     end
 end)
 
 lib.registerMenu({
-    id = 'qb_adminmenu_player_extra_menu',
+    id = 'qbx_adminmenu_player_extra_menu',
     title = Lang:t('player_options.label2'),
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, ('qb_adminmenu_player_menu_%s'):format(selectedPlayer?.id))
+        CloseMenu(false, keyPressed, ('qbx_adminmenu_player_menu_%s'):format(selectedPlayer?.id))
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_player_extra_menu = selected
+        MenuIndexes.qbx_adminmenu_player_extra_menu = selected
     end,
     options = {
         {label = 'Open Inventory'},
@@ -286,31 +286,31 @@ lib.registerMenu({
     if selected == 1 then
         ExecuteCommand(('viewinv %s'):format(selectedPlayer.id))
     elseif selected == 2 then
-        local succeeded = lib.callback.await('qb-admin:server:clothingMenu', false, selectedPlayer.id)
+        local succeeded = lib.callback.await('qbx_admin:server:clothingMenu', false, selectedPlayer.id)
         if succeeded then return end
-        lib.showMenu('qb_adminmenu_player_extra_menu', MenuIndexes.qb_adminmenu_player_extra_menu)
+        lib.showMenu('qbx_adminmenu_player_extra_menu', MenuIndexes.qbx_adminmenu_player_extra_menu)
     elseif selected == 3 then
         local dialog = lib.inputDialog('Give Item', {
             {type = 'input', label = 'Item', placeholder = 'phone'},
             {type = 'number', label = 'Amount', default = 1}
         })
         if not dialog or not dialog[1] or dialog[1] == '' or not dialog[2] or dialog[2] < 1 then
-            lib.showMenu('qb_adminmenu_player_extra_menu', MenuIndexes.qb_adminmenu_player_extra_menu)
+            lib.showMenu('qbx_adminmenu_player_extra_menu', MenuIndexes.qbx_adminmenu_player_extra_menu)
             return
         end
         ExecuteCommand('giveitem ' .. selectedPlayer.id .. ' ' .. dialog[1] .. ' ' .. dialog[2])
     elseif selected == 4 then
-        local sounds = lib.callback.await('qb-admin:server:getSounds', false)
+        local sounds = lib.callback.await('qbx_admin:server:getSounds', false)
         if not sounds then
-            lib.showMenu('qb_adminmenu_player_extra_menu', MenuIndexes.qb_adminmenu_player_extra_menu)
+            lib.showMenu('qbx_adminmenu_player_extra_menu', MenuIndexes.qbx_adminmenu_player_extra_menu)
             return
         end
 
         for i = 1, #sounds do
-            lib.setMenuOptions('qb_adminmenu_play_sounds_menu', {label = sounds[i], description = 'Press enter to play this sound', args = {sounds[i]}, close = false}, i + 2)
+            lib.setMenuOptions('qbx_adminmenu_play_sounds_menu', {label = sounds[i], description = 'Press enter to play this sound', args = {sounds[i]}, close = false}, i + 2)
         end
 
-        lib.showMenu('qb_adminmenu_play_sounds_menu', MenuIndexes.qb_adminmenu_play_sounds_menu)
+        lib.showMenu('qbx_adminmenu_play_sounds_menu', MenuIndexes.qbx_adminmenu_play_sounds_menu)
     elseif selected == 5 then
         exports['pma-voice']:toggleMutePlayer(selectedPlayer.id)
     end
@@ -320,24 +320,24 @@ local volume = {1, 0.1}
 local radius = {1, 10}
 
 lib.registerMenu({
-    id = 'qb_adminmenu_play_sounds_menu',
+    id = 'qbx_adminmenu_play_sounds_menu',
     title = 'Play Sounds',
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, 'qb_adminmenu_player_extra_menu')
+        CloseMenu(false, keyPressed, 'qbx_adminmenu_player_extra_menu')
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_play_sounds_menu = selected
+        MenuIndexes.qbx_adminmenu_play_sounds_menu = selected
     end,
     onSideScroll = function(_, scrollIndex, args)
         if args == 'volume' then
             if scrollIndex == 11 then return end
             volume[2] = scrollIndex / 10
-            lib.setMenuOptions('qb_adminmenu_play_sounds_menu', {label = 'Volume', args = {'volume'}, values = {'0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0', 'Input'}, defaultIndex = scrollIndex, close = false}, 1)
+            lib.setMenuOptions('qbx_adminmenu_play_sounds_menu', {label = 'Volume', args = {'volume'}, values = {'0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0', 'Input'}, defaultIndex = scrollIndex, close = false}, 1)
         elseif args == 'radius' then
             if scrollIndex == 11 then return end
             radius[2] = scrollIndex * 10
-            lib.setMenuOptions('qb_adminmenu_play_sounds_menu', {label = 'Radius', args = {'radius'}, values = {'10', '20', '30', '40', '50', '60', '70', '80', '90', '100', 'Input'}, defaultIndex = scrollIndex, close = false}, 2)
+            lib.setMenuOptions('qbx_adminmenu_play_sounds_menu', {label = 'Radius', args = {'radius'}, values = {'10', '20', '30', '40', '50', '60', '70', '80', '90', '100', 'Input'}, defaultIndex = scrollIndex, close = false}, 2)
         end
     end,
     options = {
@@ -351,7 +351,7 @@ lib.registerMenu({
         local dialog = lib.inputDialog('Set Volume Manually', {'Volume (0.00 - 1.00'})
         if not dialog or not dialog[1] or dialog[1] == '' or not tonumber(dialog[1]) then
             Wait(200)
-            lib.showMenu('qb_adminmenu_play_sounds_menu', MenuIndexes.qb_adminmenu_play_sounds_menu)
+            lib.showMenu('qbx_adminmenu_play_sounds_menu', MenuIndexes.qbx_adminmenu_play_sounds_menu)
             return
         end
 
@@ -360,14 +360,14 @@ lib.registerMenu({
         if result < 0 or result > 1 then
             lib.notify({ description = 'The number has to be between 0.00 and 1.00', type = 'error' })
             Wait(200)
-            lib.showMenu('qb_adminmenu_play_sounds_menu', MenuIndexes.qb_adminmenu_play_sounds_menu)
+            lib.showMenu('qbx_adminmenu_play_sounds_menu', MenuIndexes.qbx_adminmenu_play_sounds_menu)
             return
         end
 
         volume[2] = result --[[@as number]]
-        lib.setMenuOptions('qb_adminmenu_play_sounds_menu', {label = 'Volume', args = {'volume'}, values = {'0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0', 'Input'}, defaultIndex = scrollIndex, close = false}, 1)
+        lib.setMenuOptions('qbx_adminmenu_play_sounds_menu', {label = 'Volume', args = {'volume'}, values = {'0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1.0', 'Input'}, defaultIndex = scrollIndex, close = false}, 1)
         Wait(200)
-        lib.showMenu('qb_adminmenu_play_sounds_menu', MenuIndexes.qb_adminmenu_play_sounds_menu)
+        lib.showMenu('qbx_adminmenu_play_sounds_menu', MenuIndexes.qbx_adminmenu_play_sounds_menu)
         return
     elseif args[1] == 'radius' then
         if scrollIndex ~= 11 then return end
@@ -375,7 +375,7 @@ lib.registerMenu({
         local dialog = lib.inputDialog('Set Radius Manually', {'Radius (1 - 100'})
         if not dialog or not dialog[1] or dialog[1] == '' or not tonumber(dialog[1]) then
             Wait(200)
-            lib.showMenu('qb_adminmenu_play_sounds_menu', MenuIndexes.qb_adminmenu_play_sounds_menu)
+            lib.showMenu('qbx_adminmenu_play_sounds_menu', MenuIndexes.qbx_adminmenu_play_sounds_menu)
             return
         end
 
@@ -384,14 +384,14 @@ lib.registerMenu({
         if result < 1 or result > 100 then
             lib.notify({ description = 'The number has to be between 1 and 100', type = 'error' })
             Wait(200)
-            lib.showMenu('qb_adminmenu_play_sounds_menu', MenuIndexes.qb_adminmenu_play_sounds_menu)
+            lib.showMenu('qbx_adminmenu_play_sounds_menu', MenuIndexes.qbx_adminmenu_play_sounds_menu)
             return
         end
 
         radius[2] = result --[[@as number]]
-        lib.setMenuOptions('qb_adminmenu_play_sounds_menu', {label = 'Radius', args = {'radius'}, values = {'10', '20', '30', '40', '50', '60', '70', '80', '90', '100', 'Input'}, defaultIndex = scrollIndex, close = false}, 2)
+        lib.setMenuOptions('qbx_adminmenu_play_sounds_menu', {label = 'Radius', args = {'radius'}, values = {'10', '20', '30', '40', '50', '60', '70', '80', '90', '100', 'Input'}, defaultIndex = scrollIndex, close = false}, 2)
         Wait(200)
-        lib.showMenu('qb_adminmenu_play_sounds_menu', MenuIndexes.qb_adminmenu_play_sounds_menu)
+        lib.showMenu('qbx_adminmenu_play_sounds_menu', MenuIndexes.qbx_adminmenu_play_sounds_menu)
         return
     end
 

--- a/client/server.lua
+++ b/client/server.lua
@@ -6,7 +6,7 @@ local Options = {
             { type = 'number', label = Lang:t('server_options.input3label'), placeholder = '25'}
         })
         if not Input then return end if not Input[1] then return end
-        lib.callback('qb-admin:callback:getradiolist', false, function(Players, Frequency)
+        lib.callback('qbx_admin:callback:getradiolist', false, function(Players, Frequency)
             local OptionsList = {}
             for i = 1, #Players do OptionsList[#OptionsList + 1] = {title = Players[i].name .. ' | ' .. Players[i].id} end
             lib.registerContext({id = 'frequency_list', title = 'Frequency ' .. Frequency, options = OptionsList })
@@ -22,14 +22,14 @@ local Options = {
 }
 
 lib.registerMenu({
-    id = 'qb_adminmenu_server_menu',
+    id = 'qbx_adminmenu_server_menu',
     title = Lang:t('title.server_menu'),
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, 'qb_adminmenu_main_menu')
+        CloseMenu(false, keyPressed, 'qbx_adminmenu_main_menu')
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_server_menu = selected
+        MenuIndexes.qbx_adminmenu_server_menu = selected
     end,
     options = {
         {label = Lang:t('server_options.label1'), description = Lang:t('server_options.desc1'), icon = 'fas fa-cloud', values = {Lang:t('server_options.value1_1'), Lang:t('server_options.value1_2'), Lang:t('server_options.value1_3'), Lang:t('server_options.value1_4'), Lang:t('server_options.value1_5'), Lang:t('server_options.value1_6'),

--- a/client/vectors.lua
+++ b/client/vectors.lua
@@ -42,6 +42,6 @@ function CopyToClipboard(dataType)
     end
 end
 
-RegisterNetEvent('qb-admin:client:copyToClipboard', function(dataType)
+RegisterNetEvent('qbx_admin:client:copyToClipboard', function(dataType)
     CopyToClipboard(dataType)
 end)

--- a/client/vehicle.lua
+++ b/client/vehicle.lua
@@ -1,8 +1,8 @@
 local coreVehicles = exports.qbx_core:GetVehiclesByName()
 function GenerateVehiclesSpawnMenu()
-    local canUseMenu = lib.callback.await('qb-admin:server:canUseMenu', false)
+    local canUseMenu = lib.callback.await('qbx_admin:server:canUseMenu', false)
     if not canUseMenu then
-        lib.showMenu('qb_adminmenu_main_menu', MenuIndexes.qb_adminmenu_main_menu)
+        lib.showMenu('qbx_adminmenu_main_menu', MenuIndexes.qbx_adminmenu_main_menu)
         return
     end
 
@@ -27,21 +27,21 @@ function GenerateVehiclesSpawnMenu()
     end)
 
     for i = 1, #categories do
-        lib.setMenuOptions('qb_adminmenu_spawn_vehicles_menu', {label = string.firstToUpper(categories[i]), args = {('qb_adminmenu_spawn_vehicles_menu_%s'):format(categories[i])}}, i)
+        lib.setMenuOptions('qbx_adminmenu_spawn_vehicles_menu', {label = string.firstToUpper(categories[i]), args = {('qbx_adminmenu_spawn_vehicles_menu_%s'):format(categories[i])}}, i)
 
         lib.registerMenu({
-            id = ('qb_adminmenu_spawn_vehicles_menu_%s'):format(categories[i]),
+            id = ('qbx_adminmenu_spawn_vehicles_menu_%s'):format(categories[i]),
             title = categories[i],
             position = 'top-right',
             onClose = function(keyPressed)
-                CloseMenu(false, keyPressed, 'qb_adminmenu_spawn_vehicles_menu')
+                CloseMenu(false, keyPressed, 'qbx_adminmenu_spawn_vehicles_menu')
             end,
             onSelected = function(selected)
-                MenuIndexes[('qb_adminmenu_spawn_vehicles_menu_%s'):format(categories[i])] = selected
+                MenuIndexes[('qbx_adminmenu_spawn_vehicles_menu_%s'):format(categories[i])] = selected
             end,
             options = {}
         }, function(_, _, args)
-            local vehNetId = lib.callback.await('qb-admin:server:spawnVehicle', false, args[1])
+            local vehNetId = lib.callback.await('qbx_admin:server:spawnVehicle', false, args[1])
             if not vehNetId then return end
             local veh
             repeat
@@ -73,22 +73,22 @@ function GenerateVehiclesSpawnMenu()
 
     for i = 1, #vehs do
         local v = coreVehicles[vehs[i]]
-        lib.setMenuOptions(('qb_adminmenu_spawn_vehicles_menu_%s'):format(v.category), {label = v.name, args = {v.model}}, indexedCategories[v.category])
+        lib.setMenuOptions(('qbx_adminmenu_spawn_vehicles_menu_%s'):format(v.category), {label = v.name, args = {v.model}}, indexedCategories[v.category])
         indexedCategories[v.category] += 1
     end
 
-    lib.showMenu('qb_adminmenu_spawn_vehicles_menu', MenuIndexes.qb_adminmenu_spawn_vehicles_menu)
+    lib.showMenu('qbx_adminmenu_spawn_vehicles_menu', MenuIndexes.qbx_adminmenu_spawn_vehicles_menu)
 end
 
 lib.registerMenu({
-    id = 'qb_adminmenu_vehicles_menu',
+    id = 'qbx_adminmenu_vehicles_menu',
     title = 'Vehicles',
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, 'qb_adminmenu_main_menu')
+        CloseMenu(false, keyPressed, 'qbx_adminmenu_main_menu')
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_vehicles_menu = selected
+        MenuIndexes.qbx_adminmenu_vehicles_menu = selected
     end,
     options = {
         {label = 'Spawn Vehicle'},
@@ -110,7 +110,7 @@ lib.registerMenu({
     elseif selected == 5 then
         if not cache.vehicle then
             lib.notify({ description = 'You have to be in a vehicle, to use this', type = 'error' })
-            lib.showMenu('qb_adminmenu_vehicles_menu', MenuIndexes.qb_adminmenu_vehicles_menu)
+            lib.showMenu('qbx_adminmenu_vehicles_menu', MenuIndexes.qbx_adminmenu_vehicles_menu)
             return
         end
         local override = {
@@ -137,21 +137,21 @@ lib.registerMenu({
     elseif selected == 6 then
         if not cache.vehicle then
             lib.notify({ description = 'You have to be in a vehicle, to use this', type = 'error' })
-            lib.showMenu('qb_adminmenu_vehicles_menu', MenuIndexes.qb_adminmenu_vehicles_menu)
+            lib.showMenu('qbx_adminmenu_vehicles_menu', MenuIndexes.qbx_adminmenu_vehicles_menu)
             return
         end
         local dialog = lib.inputDialog('Custom License Plate (Max. 8 characters)',  {'License Plate'})
 
         if not dialog or not dialog[1] or dialog[1] == '' then
             Wait(200)
-            lib.showMenu('qb_adminmenu_vehicles_menu', MenuIndexes.qb_adminmenu_vehicles_menu)
+            lib.showMenu('qbx_adminmenu_vehicles_menu', MenuIndexes.qbx_adminmenu_vehicles_menu)
             return
         end
 
         if #dialog[1] > 8 then
             Wait(200)
             lib.notify({ description = 'You can only enter a maximum of 8 characters', type = 'error' })
-            lib.showMenu('qb_adminmenu_vehicles_menu', MenuIndexes.qb_adminmenu_vehicles_menu)
+            lib.showMenu('qbx_adminmenu_vehicles_menu', MenuIndexes.qbx_adminmenu_vehicles_menu)
             return
         end
 
@@ -160,14 +160,14 @@ lib.registerMenu({
 end)
 
 lib.registerMenu({
-    id = 'qb_adminmenu_spawn_vehicles_menu',
+    id = 'qbx_adminmenu_spawn_vehicles_menu',
     title = 'Spawn Vehicle',
     position = 'top-right',
     onClose = function(keyPressed)
-        CloseMenu(false, keyPressed, 'qb_adminmenu_main_menu')
+        CloseMenu(false, keyPressed, 'qbx_adminmenu_main_menu')
     end,
     onSelected = function(selected)
-        MenuIndexes.qb_adminmenu_spawn_vehicles_menu = selected
+        MenuIndexes.qbx_adminmenu_spawn_vehicles_menu = selected
     end,
     options = {}
 }, function(_, _, args)

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -2,28 +2,28 @@ lib.addCommand('admin', {
     help = 'Opens Adminmenu',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:openmenu', source)
+    TriggerClientEvent('qbx_admin:client:openMenu', source)
 end)
 
 lib.addCommand('noclip', {
     help = 'Toggle NoClip',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:noclip', source)
+    TriggerClientEvent('qbx_admin:client:noclip', source)
 end)
 
 lib.addCommand('names', {
     help = 'Toggle Player Names',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:names', source)
+    TriggerClientEvent('qbx_admin:client:names', source)
 end)
 
 lib.addCommand('blips', {
     help = 'Toggle Player Blips',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:blips', source)
+    TriggerClientEvent('qbx_admin:client:blips', source)
 end)
 
 lib.addCommand('setmodel', {
@@ -38,33 +38,33 @@ lib.addCommand('setmodel', {
 
     if not exports.qbx_core:GetPlayer(Target) then return end
 
-    TriggerClientEvent('qb-admin:client:setmodel', Target, args.model)
+    TriggerClientEvent('qbx_admin:client:setModel', Target, args.model)
 end)
 
 lib.addCommand('vec2', {
     help = 'Copy vector2 to clipboard (Admin only)',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:copyToClipboard', source, 'coords2')
+    TriggerClientEvent('qbx_admin:client:copyToClipboard', source, 'coords2')
 end)
 
 lib.addCommand('vec3', {
     help = 'Copy vector3 to clipboard (Admin only)',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:copyToClipboard', source, 'coords3')
+    TriggerClientEvent('qbx_admin:client:copyToClipboard', source, 'coords3')
 end)
 
 lib.addCommand('vec4', {
     help = 'Copy vector4 to clipboard (Admin only)',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:copyToClipboard', source, 'coords4')
+    TriggerClientEvent('qbx_admin:client:copyToClipboard', source, 'coords4')
 end)
 
 lib.addCommand('heading', {
     help = 'Copy heading to clipboard (Admin only)',
     restricted = 'admin',
 }, function(source)
-    TriggerClientEvent('qb-admin:client:copyToClipboard', source, 'heading')
+    TriggerClientEvent('qbx_admin:client:copyToClipboard', source, 'heading')
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -49,7 +49,7 @@ local GeneralOptions = {
         SetPlayerRoutingBucket(SelectedPlayer.id, Input)
     end,
 }
-RegisterNetEvent('qb-admin:server:playeroptionsgeneral', function(Selected, SelectedPlayer, Input)
+RegisterNetEvent('qbx_admin:server:playerOptionsGeneral', function(Selected, SelectedPlayer, Input)
     if not exports.qbx_core:HasPermission(source, Config.Events['playeroptionsgeneral']) then NoPerms(source) return end
 
     ---@diagnostic disable-next-line: redundant-parameter
@@ -75,7 +75,7 @@ local AdministrationOptions = {
         if Input == 'remove' then exports.qbx_core:RemovePermission(SelectedPlayer.id) else exports.qbx_core:AddPermission(SelectedPlayer.id, Input) end
     end,
 }
-RegisterNetEvent('qb-admin:server:playeradministration', function(Selected, SelectedPlayer, Input)
+RegisterNetEvent('qbx_admin:server:playerAdministration', function(Selected, SelectedPlayer, Input)
     AdministrationOptions[Selected](source, SelectedPlayer, Input)
 end)
 
@@ -113,7 +113,7 @@ local PlayerDataOptions = {
         exports['pma-voice']:setPlayerRadio(Target.PlayerData.source, Input[1])
     end,
 }
-RegisterNetEvent('qb-admin:server:changeplayerdata', function(Selected, SelectedPlayer, Input)
+RegisterNetEvent('qbx_admin:server:changePlayerData', function(Selected, SelectedPlayer, Input)
     local Target = exports.qbx_core:GetPlayer(SelectedPlayer.id)
 
     if not exports.qbx_core:HasPermission(source, Config.Events['changeplayerdata']) then NoPerms(source) return end
@@ -122,7 +122,7 @@ RegisterNetEvent('qb-admin:server:changeplayerdata', function(Selected, Selected
     PlayerDataOptions[Selected](Target, Input)
 end)
 
-RegisterNetEvent('qb-admin:server:giveallweapons', function(Weapontype, PlayerID)
+RegisterNetEvent('qbx_admin:server:giveAllWeapons', function(Weapontype, PlayerID)
     local src = PlayerID or source
     local Target = exports.qbx_core:GetPlayer(src)
 
@@ -134,7 +134,7 @@ RegisterNetEvent('qb-admin:server:giveallweapons', function(Weapontype, PlayerID
     end
 end)
 
-lib.callback.register('qb-admin:callback:getradiolist', function(source, Frequency)
+lib.callback.register('qbx_admin:callback:getradiolist', function(source, Frequency)
     local list = exports['pma-voice']:getPlayersInRadioChannel(tonumber(Frequency))
     local Players = {}
 
@@ -150,7 +150,7 @@ lib.callback.register('qb-admin:callback:getradiolist', function(source, Frequen
     return Players, Frequency
 end)
 
-lib.callback.register('qb-admin:server:getplayers', function(source)
+lib.callback.register('qbx_admin:server:getPlayers', function(source)
     if not exports.qbx_core:HasPermission(source, Config.Events['usemenu']) then NoPerms(source) return end
 
     local Players = {}
@@ -179,7 +179,7 @@ lib.callback.register('qb-admin:server:getplayers', function(source)
     return Players
 end)
 
-lib.callback.register('qb-admin:server:getplayer', function(source, playerToGet)
+lib.callback.register('qbx_admin:server:getPlayer', function(source, playerToGet)
     if not exports.qbx_core:HasPermission(source, Config.Events['usemenu']) then NoPerms(source) return end
 
     local playerData = exports.qbx_core:GetPlayer(playerToGet).PlayerData
@@ -205,7 +205,7 @@ lib.callback.register('qb-admin:server:getplayer', function(source, playerToGet)
     return player
 end)
 
-lib.callback.register('qb-admin:server:clothingMenu', function(source, target)
+lib.callback.register('qbx_admin:server:clothingMenu', function(source, target)
     if not exports.qbx_core:HasPermission(source, Config.Events['clothing menu']) then
         NoPerms(source)
         return false
@@ -216,7 +216,7 @@ lib.callback.register('qb-admin:server:clothingMenu', function(source, target)
     return true
 end)
 
-lib.callback.register('qb-admin:server:getSounds', function(source)
+lib.callback.register('qbx_admin:server:getSounds', function(source)
     if not exports.qbx_core:HasPermission(source, Config.Events['play sounds']) then
         NoPerms(source)
         return
@@ -224,7 +224,7 @@ lib.callback.register('qb-admin:server:getSounds', function(source)
     return sounds
 end)
 
-lib.callback.register('qb-admin:server:canUseMenu', function(source)
+lib.callback.register('qbx_admin:server:canUseMenu', function(source)
     if not exports.qbx_core:HasPermission(source, Config.Events['usemenu']) then
         NoPerms(source)
         return false
@@ -233,7 +233,7 @@ lib.callback.register('qb-admin:server:canUseMenu', function(source)
     return true
 end)
 
-lib.callback.register('qb-admin:server:spawnVehicle', function(source, model)
+lib.callback.register('qbx_admin:server:spawnVehicle', function(source, model)
     local hash = joaat(model)
     return SpawnVehicle(source, hash, nil, true)
 end)


### PR DESCRIPTION
## Description

Rename event and menu names from qb-admin to qbx_admin along with camelCasing some of the event names which didn't already have it.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
