### PR TITLE
fix: oal/routing bucket issue

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -8,7 +8,7 @@ local sounds = {}
 function CheckRoutingbucket(source, target)
     local sourceBucket = GetPlayerRoutingBucket(source)
     local targetBucket = GetPlayerRoutingBucket(target)
-    if sourceBucket ~= targetBucket then SetPlayerRoutingBucket(source, targetBucket) end
+    if sourceBucket ~= targetBucket then SetPlayerRoutingBucket(tonumber(source), targetBucket) end
 end
 
 local generalOptions = {
@@ -42,7 +42,7 @@ local generalOptions = {
         SetPedIntoVehicle(GetPlayerPed(source), vehicle, seat)
     end,
     function(selectedPlayer, _, input)
-        SetPlayerRoutingBucket(selectedPlayer.id, input)
+        SetPlayerRoutingBucket(tonumber(selectedPlayer.id), input)
     end,
 }
 RegisterNetEvent('qbx_admin:server:playerOptionsGeneral', function(selected, selectedPlayer, input)


### PR DESCRIPTION
## Description

Routing bucket changes to not work with OAL without `tonumber()`. For more info see https://github.com/Qbox-project/qbx_houserobbery/pull/7

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
