### PR TITLE
fix: use correct ace perms

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -1,23 +1,23 @@
 return {
     commandPerms = {
-        useMenu = 'mod',
-        noclip = 'mod',
-        names = 'mod',
-        blips = 'mod',
-        setModel = 'admin',
-        dev = 'admin',
+        useMenu = 'group.mod',
+        noclip = 'group.mod',
+        names = 'group.mod',
+        blips = 'group.mod',
+        setModel = 'group.admin',
+        dev = 'group.admin',
     },
 
     eventPerms = {
-        playerOptionsGeneral = 'mod',
-        kick = 'mod',
-        ban = 'admin',
-        changePerms = 'admin',
-        changePlayerData = 'admin',
-        giveAllWeapons = 'admin',
-        getRadioList = 'mod',
-        useMenu = 'mod',
-        clothingMenu = 'admin',
+        playerOptionsGeneral = 'group.mod',
+        kick = 'group.mod',
+        ban = 'group.admin',
+        changePerms = 'group.admin',
+        changePlayerData = 'group.admin',
+        giveAllWeapons = 'group.admin',
+        getRadioList = 'group.mod',
+        useMenu = 'group.mod',
+        clothingMenu = 'group.admin',
     },
 
     weaponList = {

--- a/config/server.lua
+++ b/config/server.lua
@@ -1,23 +1,23 @@
 return {
     commandPerms = {
-        useMenu = 'group.mod',
-        noclip = 'group.mod',
-        names = 'group.mod',
-        blips = 'group.mod',
-        setModel = 'group.admin',
-        dev = 'group.admin',
+        useMenu = 'mod',
+        noclip = 'mod',
+        names = 'mod',
+        blips = 'mod',
+        setModel = 'admin',
+        dev = 'admin',
     },
 
     eventPerms = {
-        playerOptionsGeneral = 'group.mod',
-        kick = 'group.mod',
-        ban = 'group.admin',
-        changePerms = 'group.admin',
-        changePlayerData = 'group.admin',
-        giveAllWeapons = 'group.admin',
-        getRadioList = 'group.mod',
-        useMenu = 'group.mod',
-        clothingMenu = 'group.admin',
+        playerOptionsGeneral = 'mod',
+        kick = 'mod',
+        ban = 'admin',
+        changePerms = 'admin',
+        changePlayerData = 'admin',
+        giveAllWeapons = 'admin',
+        getRadioList = 'mod',
+        useMenu = 'mod',
+        clothingMenu = 'admin',
     },
 
     weaponList = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -46,7 +46,7 @@ local generalOptions = {
     end,
 }
 RegisterNetEvent('qbx_admin:server:playerOptionsGeneral', function(selected, selectedPlayer, input)
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.playerOptionsGeneral) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+    if not IsPlayerAceAllowed(source, config.eventPerms.playerOptionsGeneral) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
 
     ---@diagnostic disable-next-line: redundant-parameter
     generalOptions[selected](selectedPlayer, source, input)
@@ -54,11 +54,11 @@ end)
 
 local administrationOptions = {
     function(source, selectedPlayer, input)
-        if not exports.qbx_core:HasPermission(source, config.eventPerms.kick) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+        if not IsPlayerAceAllowed(source, config.eventPerms.kick) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
         DropPlayer(selectedPlayer.id, input)
     end,
     function(source, selectedPlayer, input)
-        if not exports.qbx_core:HasPermission(source, config.eventPerms.ban) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+        if not IsPlayerAceAllowed(source, config.eventPerms.ban) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
         local banDuration = (input[2] or 0) * 3600 + (input[3] or 0) * 86400 + (input[4] or 0) * 2629743
         DropPlayer(selectedPlayer.id, locale('player_options.administration.banreason', input[1], os.date('%c', os.time() + banDuration)))
         MySQL.Async.insert('INSERT INTO bans (name, license, discord, ip, reason, expire, bannedby) VALUES (?, ?, ?, ?, ?, ?, ?)', {
@@ -67,7 +67,7 @@ local administrationOptions = {
         })
     end,
     function(source, selectedPlayer, input)
-        if not exports.qbx_core:HasPermission(source, config.eventPerms.changePerms) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+        if not IsPlayerAceAllowed(source, config.eventPerms.changePerms) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
         if input == 'remove' then exports.qbx_core:RemovePermission(selectedPlayer.id) else exports.qbx_core:AddPermission(selectedPlayer.id, input) end
     end,
 }
@@ -112,7 +112,7 @@ local playerDataOptions = {
 RegisterNetEvent('qbx_admin:server:changePlayerData', function(selected, selectedPlayer, input)
     local target = exports.qbx_core:GetPlayer(selectedPlayer.id)
 
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.changePlayerData) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+    if not IsPlayerAceAllowed(source, config.eventPerms.changePlayerData) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
     if not target then return end
 
     playerDataOptions[selected](target, input)
@@ -122,7 +122,7 @@ RegisterNetEvent('qbx_admin:server:giveAllWeapons', function(weaponType, playerI
     local src = playerID or source
     local target = exports.qbx_core:GetPlayer(src)
 
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.giveAllWeapons) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+    if not IsPlayerAceAllowed(source, config.eventPerms.giveAllWeapons) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
 
     for i = 1, #config.weaponList[weaponType], 1 do
         if not exports.ox_inventory:Items()[config.weaponList[weaponType][i]] then return end
@@ -134,7 +134,7 @@ lib.callback.register('qbx_admin:callback:getradiolist', function(source, freque
     local list = exports['pma-voice']:getPlayersInRadioChannel(tonumber(frequency))
     local players = {}
 
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.getRadioList) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+    if not IsPlayerAceAllowed(source, config.eventPerms.getRadioList) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
 
     for targetSource, _ in pairs(list) do -- cheers Knight who shall not be named
         local player = exports.qbx_core:GetPlayer(targetSource)
@@ -147,7 +147,7 @@ lib.callback.register('qbx_admin:callback:getradiolist', function(source, freque
 end)
 
 lib.callback.register('qbx_admin:server:getPlayers', function(source)
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.useMenu) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+    if not IsPlayerAceAllowed(source, config.eventPerms.useMenu) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
 
     local players = {}
     for k, v in pairs(exports.qbx_core:GetQBPlayers()) do
@@ -176,7 +176,7 @@ lib.callback.register('qbx_admin:server:getPlayers', function(source)
 end)
 
 lib.callback.register('qbx_admin:server:getPlayer', function(source, playerToGet)
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.useMenu) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
+    if not IsPlayerAceAllowed(source, config.eventPerms.useMenu) then exports.qbx_core:Notify(source, locale('error.no_perms'), 'error') return end
 
     local playerData = exports.qbx_core:GetPlayer(playerToGet).PlayerData
     local player = {
@@ -202,7 +202,7 @@ lib.callback.register('qbx_admin:server:getPlayer', function(source, playerToGet
 end)
 
 lib.callback.register('qbx_admin:server:clothingMenu', function(source, target)
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.clothingMenu) then
+    if not IsPlayerAceAllowed(source, config.eventPerms.clothingMenu) then
         exports.qbx_core:Notify(source, locale('error.no_perms'), 'error')
         return false
     end
@@ -213,7 +213,7 @@ lib.callback.register('qbx_admin:server:clothingMenu', function(source, target)
 end)
 
 lib.callback.register('qbx_admin:server:canUseMenu', function(source)
-    if not exports.qbx_core:HasPermission(source, config.eventPerms.useMenu) then
+    if not IsPlayerAceAllowed(source, config.eventPerms.useMenu) then
         exports.qbx_core:Notify(source, locale('error.no_perms'), 'error')
         return false
     end


### PR DESCRIPTION
exports.qbx_core:HasPermission only looks at the last part of the ace perm. 'group.' causes it to not match.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Fixes issue with stock qbox admin permissions preventing the admin menu from working

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
