### PR TITLE
Update server.lua

### DIFF
--- a/client/server.lua
+++ b/client/server.lua
@@ -3,7 +3,7 @@ local options = {
     function(time) TriggerServerEvent('qb-weathersync:server:setTime', time) end,
     function()
         local input = lib.inputDialog(locale('server_options.label3'), {
-            {type = 'number', label = locale('server_options.input3label'), placeholder = '25'}
+            {type = 'number', label = locale('server_options.input3label'), min = 0, max = 1000}
         })
         if not input then return end if not input[1] then return end
         lib.callback('qbx_admin:callback:getradiolist', false, function(players, frequency)


### PR DESCRIPTION
## Description

This Fix allows the admin to get the radio list also of the subchannels (decimals) allowed in qbx_radio

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X ] My pull request fits the contribution guidelines & code conventions.
