### PR TITLE
feat: qbx_vehiclekeys admin commands

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -161,5 +161,14 @@
     "blips_deactivated": "Blips deactivated",
     "names_deactivated": "Names deactivated",
     "no_report_reply": "Reply failed to send due to no message"
+  },
+  "commands": {
+    "vehiclekeys": {
+      "help_addkeys": "Adds keys to a vehicle for someone.",
+      "help_removekeys": "Remove keys to a vehicle for someone.",
+      "help_id": "Player ID (admin id on nil)",
+      "help_plate": "Plate (current vehicle on nil)",
+      "error": "Fill out the player ID and Plate arguments"
+    }
   }
 }

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -119,7 +119,7 @@ lib.addCommand('heading', {
 end)
 
 local function getVehicleKeysParams(source, args)
-    local playerId = args.id
+    local playerId = args.target
     local plate = args.plate
 
     if not playerId then
@@ -143,8 +143,8 @@ local vehiclekeysArgs = {
         optional = true
     },
     {
-        name = 'id',
-        type = 'number',
+        name = 'target',
+        type = 'playerId',
         help = locale('commands.vehiclekeys.help_id'),
         optional = true
     }

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -171,7 +171,7 @@ lib.addCommand('removekeys', {
 }, function (source, args)
     local playerId, plate = getVehicleKeysParams(source, args)
 
-    if not playerId or not plate == 0  then
+    if not playerId or plate == 0 then
         return exports.qbx_core:Notify(source, locale('commands.vehiclekeys.error'), 'error')
     end
 

--- a/server/commands.lua
+++ b/server/commands.lua
@@ -117,3 +117,63 @@ lib.addCommand('heading', {
 }, function(source)
     TriggerClientEvent('qbx_admin:client:copyToClipboard', source, 'heading')
 end)
+
+local function getVehicleKeysParams(source, args)
+    local playerId = args.id
+    local plate = args.plate
+
+    if not playerId then
+        playerId = source
+    end
+
+    if not plate then
+        local ped = GetPlayerPed(source)
+        local vehicle = GetVehiclePedIsIn(ped, false);
+        plate = GetVehicleNumberPlateText(vehicle)
+    end
+
+    return playerId, plate
+end
+
+local vehiclekeysArgs = {
+    {
+        name = 'plate',
+        type = 'string',
+        help = locale("commands.vehiclekeys.help_plate"),
+        optional = true
+    },
+    {
+        name = 'id',
+        type = 'number',
+        help = locale('commands.vehiclekeys.help_id'),
+        optional = true
+    }
+}
+
+lib.addCommand('addkeys', {
+    help = locale('commands.vehiclekeys.help_addkeys'),
+    params = vehiclekeysArgs,
+    restricted = config.dev
+}, function (source, args)
+    local playerId, plate = getVehicleKeysParams(source, args)
+
+    if not playerId or plate == 0 then
+        return exports.qbx_core:Notify(source, locale('commands.vehiclekeys.error'), 'error')
+    end
+
+    TriggerEvent('qbx_vehiclekeys:server:giveKeys', playerId, plate)
+end)
+
+lib.addCommand('removekeys', {
+    help = locale('commands.vehiclekeys.help_removekeys'),
+    params = vehiclekeysArgs,
+    restricted = config.dev
+}, function (source, args)
+    local playerId, plate = getVehicleKeysParams(source, args)
+
+    if not playerId or not plate == 0  then
+        return exports.qbx_core:Notify(source, locale('commands.vehiclekeys.error'), 'error')
+    end
+
+    TriggerEvent('qbx_vehiclekeys:server:removeKeys', playerId, plate)
+end)


### PR DESCRIPTION
## Description

Move admin commands from qbx_vehiclekeys.
Default values of the commands, indicating to the admin id and vehicle admin is sitting in.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
