### PR TITLE
Update admin.lua

### DIFF
--- a/client/admin.lua
+++ b/client/admin.lua
@@ -514,7 +514,12 @@ lib.callback.register('qbx_admin:client:SaveCarDialog', function()
 end)
 
 lib.callback.register('qbx_admin:client:GetVehicleInfo', function()
-    return GetDisplayNameFromVehicleModel(GetEntityModel(cache.vehicle)):lower(), lib.getVehicleProperties(cache.vehicle)
+
+    local aheadVehHash = GetEntityModel(cache.vehicle)
+    local aheadVehName = GetDisplayNameFromVehicleModel(aheadVehHash)
+    local aheadVehNameText = GetLabelText(aheadVehName)
+    return aheadVehNameText:lower(), lib.getVehicleProperties(cache.vehicle)
+
 end)
 
 CreateThread(function()


### PR DESCRIPTION
Fixed where when using /admincar it would save only 8 char of the model for example it would save dominato instead of dominator this happens on all vehicles where spawn code is longer then 8 characters

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
