### PR TITLE
fix(server/main): use core export for routingbucket

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -104,7 +104,7 @@ local generalOptions = {
         SetPedIntoVehicle(GetPlayerPed(source), vehicle, seat)
     end,
     function(selectedPlayer, _, input)
-        SetPlayerRoutingBucket(selectedPlayer.id, input)
+        exports.qbx_core:SetPlayerBucket(selectedPlayer.id, input)
     end,
 }
 RegisterNetEvent('qbx_admin:server:playerOptionsGeneral', function(selected, selectedPlayer, input)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Currently changing the routing bucket doesn't properly change the `instance` statebag utilized by ox_inventory. Rather than duplicate that code here we use the core provided export to accomplish this

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
