### PR TITLE
fix(client/admin): return vehicle model by hash lookup vice native

### DIFF
--- a/client/admin.lua
+++ b/client/admin.lua
@@ -1,3 +1,4 @@
+local VEHICLES_HASH = exports.qbx_core:GetVehiclesByHash()
 local optionInvisible = false
 local godmode = false
 local infiniteAmmo = false
@@ -514,7 +515,7 @@ lib.callback.register('qbx_admin:client:SaveCarDialog', function()
 end)
 
 lib.callback.register('qbx_admin:client:GetVehicleInfo', function()
-    return GetDisplayNameFromVehicleModel(GetEntityModel(cache.vehicle)):lower(), lib.getVehicleProperties(cache.vehicle)
+    return VEHICLES_HASH[GetEntityModel(cache.vehicle)].model, lib.getVehicleProperties(cache.vehicle)
 end)
 
 CreateThread(function()


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
GetDisplayNameFromVehicleModel trims output to 11 characters or less. There is not a limitation for how long a vehicle model name can be. This switches the lookup to use the GetVehiclesByHash export from the core to lookup the model. This could alternatively be placed in vehicles.lua on the client side.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
