### PR TITLE
fix(permissions)!: use correct group for /admincar

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -39,7 +39,7 @@ end)
 
 lib.addCommand('admincar', {
     help = 'Buy Vehicle',
-    restricted = config.saveVeh,
+    restricted = config.saveVehicle,
 }, function(source)
     local vehicle = GetVehiclePedIsIn(GetPlayerPed(source), false)
     if vehicle == 0 then


### PR DESCRIPTION
## Description

Had my players freely use /admincar 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
